### PR TITLE
Bump numpy version to 1.24.3

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 iteration_utilities==0.11.0
 networkx==2.6.3
-numpy==1.22.3
+numpy==1.24.3
 setuptools==67.7.1

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setup(
     install_requires=[
         "iteration_utilities==0.11.0",
         "networkx==2.6.3",
-        "numpy==1.22.3",
+        "numpy==1.24.3",
     ],
 )


### PR DESCRIPTION
This PR updates the locked numpy version to 1.24.3.

This resolves dependency issues when `gcmpy` is used alongside the latest versions of the `pytorch` /`dgl` libraries, which expect a later version of the `numpy` C API.

## Tests

All tests pass.